### PR TITLE
Allow _id columns if they are specified in the :only parameter

### DIFF
--- a/lib/nilify_blanks.rb
+++ b/lib/nilify_blanks.rb
@@ -22,8 +22,11 @@ module NilifyBlanks
       
       cattr_accessor :nilify_blanks_columns
       
-      self.nilify_blanks_columns = self.content_columns.reject {|c| !c.null }.map {|c| c.name.to_s }
-      self.nilify_blanks_columns = self.nilify_blanks_columns.select {|c| options[:only].include?(c) } if options[:only]
+      if options[:only]
+        self.nilify_blanks_columns = options[:only].clone
+      else
+        self.nilify_blanks_columns = self.content_columns.reject {|c| !c.null }.map {|c| c.name.to_s }
+      end
       self.nilify_blanks_columns -= options[:except] if options[:except]
       self.nilify_blanks_columns = self.nilify_blanks_columns.map(&:to_s)
       


### PR DESCRIPTION
The current code automatically filters out primary keys, columns ending with _id or _count, and the column to track the type in a polymorphic table, because it only operates on columns that are within the array returned from Rails' `content_columns` method. But sometimes you might have a String column that ends with _id that is not a foreign key, but is used to track something else (e.g. an identifier from a remote system), and you want to use it with nilify_blanks. It seems to me that if you specify a column in the nilify_blanks `:only` parameter, you are clearly indicating you want to convert blanks to nils in that column, even if it ends with _id or is otherwise not included by `content_columns`. So this patch only queries `content_columns` if you have not given an `:only` parameter. If you give an `:only` parameter, we assume you know what you are doing and really mean for nilify_blanks to operate on all the columns you listed.
