### PR TITLE
Add rbx and JRuby compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ rvm:
   - 1.9.2
   - 1.9.3
   - 2.0.0
+  - rbx
+  - jruby-19mode
 gemfile:
   - gemfiles/3.0.gemfile
   - gemfiles/3.1.gemfile

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,8 @@
 source "http://rubygems.org"
 
+gem 'rubysl', '~> 2.0', :platforms => [:rbx]
+
+gem 'activerecord-jdbcsqlite3-adapter', :platforms => [:jruby]
+gem 'sqlite3', :platforms => [:ruby]
+
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,6 @@ require 'bundler/setup'
 require 'rake'
 require 'appraisal'
 require 'rspec/core/rake_task'
-require 'rdoc/task'
 
 desc 'Default: run unit tests.'
 task :default => [:clean, :test]
@@ -32,13 +31,19 @@ task :clean do |t|
   Dir.glob("spec/db/*.sqlite3").each {|f| FileUtils.rm f }
 end
 
-desc "Generate documentation for the plugin."
-Rake::RDocTask.new(:rdoc) do |rdoc|
-  rdoc.rdoc_dir = "rdoc"
-  rdoc.title    = "nilify_blanks"
-  rdoc.options << "--line-numbers" << "--inline-source"
-  rdoc.rdoc_files.include('README')
-  rdoc.rdoc_files.include('lib/**/*.rb')
+begin
+  require 'rdoc/task'
+
+  desc "Generate documentation for the plugin."
+  Rake::RDocTask.new(:rdoc) do |rdoc|
+    rdoc.rdoc_dir = "rdoc"
+    rdoc.title    = "nilify_blanks"
+    rdoc.options << "--line-numbers" << "--inline-source"
+    rdoc.rdoc_files.include('README')
+    rdoc.rdoc_files.include('lib/**/*.rb')
+  end
+rescue LoadError
+  puts 'RDocTask is not supported for this platform'
 end
 
 Dir["#{File.dirname(__FILE__)}/lib/tasks/*.rake"].sort.each { |ext| load ext }

--- a/gemfiles/3.0.gemfile
+++ b/gemfiles/3.0.gemfile
@@ -4,4 +4,9 @@ source "http://rubygems.org"
 
 gem "rails", "~> 3.0.9"
 
+gem 'rubysl', '~> 2.0', :platforms => [:rbx]
+
+gem 'activerecord-jdbcsqlite3-adapter', :platforms => [:jruby]
+gem 'sqlite3', :platforms => [:ruby]
+
 gemspec :path=>"../"

--- a/gemfiles/3.1.gemfile
+++ b/gemfiles/3.1.gemfile
@@ -4,4 +4,9 @@ source "http://rubygems.org"
 
 gem "rails", "~> 3.1.6"
 
+gem 'rubysl', '~> 2.0', :platforms => [:rbx]
+
+gem 'activerecord-jdbcsqlite3-adapter', :platforms => [:jruby]
+gem 'sqlite3', :platforms => [:ruby]
+
 gemspec :path=>"../"

--- a/gemfiles/3.2.gemfile
+++ b/gemfiles/3.2.gemfile
@@ -4,4 +4,9 @@ source "http://rubygems.org"
 
 gem "rails", "~> 3.2.6"
 
+gem 'rubysl', '~> 2.0', :platforms => [:rbx]
+
+gem 'activerecord-jdbcsqlite3-adapter', :platforms => [:jruby]
+gem 'sqlite3', :platforms => [:ruby]
+
 gemspec :path=>"../"

--- a/gemfiles/4.0.gemfile
+++ b/gemfiles/4.0.gemfile
@@ -4,4 +4,9 @@ source "http://rubygems.org"
 
 gem "rails", "~> 4.0.0"
 
+gem 'rubysl', '~> 2.0', :platforms => [:rbx]
+
+gem 'activerecord-jdbcsqlite3-adapter', :platforms => [:jruby]
+gem 'sqlite3', :platforms => [:ruby]
+
 gemspec :path=>"../"


### PR DESCRIPTION
1. Added rbx and jruby-19mode to the .travis.yml
2. Added/updated Gemfiles as needed, including rbx depenencies and jruby sqlite alternatives
3. Wrapped the RDocTask in a begin/rescue, as that's not supported in rbx 2.2.1 with Rails 4.
