### PR TITLE
Adjust to new way define_attribute_methods is called in Rails 4

### DIFF
--- a/lib/nilify_blanks.rb
+++ b/lib/nilify_blanks.rb
@@ -6,8 +6,9 @@ module NilifyBlanks
   module ClassMethods
 
     def define_attribute_methods
-      super
-      define_nilify_blank_methods
+      if super
+        define_nilify_blank_methods
+      end
     end
 
     def nilify_blanks(options = {})


### PR DESCRIPTION
This fixes the undef_method NameError we've been having on a model with nilify_blanks installed since we upgraded to Rails 4 and run in JRuby.

To reproduce the error, we ran a console under JRuby and used peach to parallelize a simple load process as follows:

class Foo < ActiveRecord::Base
  nilify_blanks
end

(1..10).to_a.peach {Foo.all.collect(&:name)}

With the old version of nilify_blanks, we pretty reliably got a stacktrace that looked like:
NameError: Undefined method _save_callbacks for 'Foo'
    from org/jruby/RubyModule.java:2297:in `undef_method'
    from /Users/thill/.rbenv/versions/jruby-1.7.12/lib/ruby/gems/shared/gems/activesupport-4.0.5/lib/active_support/core_ext/module/remove_method.rb:4:in`remove_possible_method'
    from /Users/thill/.rbenv/versions/jruby-1.7.12/lib/ruby/gems/shared/gems/activesupport-4.0.5/lib/active_support/core_ext/class/attribute.rb:86:in `_save_callbacks='
...

(Sometimes the NameError would be on something like #Class:0x18f7a385, and we've seen both styles interchangeably in our error tracking system).

After applying this fix, which was already proposed in the main project (see [Issue #13](https://github.com/rubiety/nilify_blanks/issues/13)), running the same tests from the console no longer produced the Undefined method error.

Note if you want to reproduce the console results, it helps make sure the class you are testing is preloaded, we did this with a simple `Foo.first` call, otherwise you might still see some errors the first time about circular dependencies.
