### PR TITLE
Use Non-deprecated Failure Message Methods for RSpec 3+

### DIFF
--- a/lib/nilify_blanks/matchers.rb
+++ b/lib/nilify_blanks/matchers.rb
@@ -1,5 +1,21 @@
 rspec_module = defined?(RSpec::Core) ? 'RSpec' : 'Spec'  # for RSpec 1 compatability
 
+def failure_message_method
+  rspec_major_version >= 3 ? :failure_message : :failure_message_for_should
+rescue
+  :failure_message_for_should
+end
+
+def negated_failure_message_method
+  rspec_major_version >= 3 ? :failure_message_when_negated : :failure_message_for_should_not
+rescue
+  :failure_message_for_should_not
+end
+
+def rspec_major_version
+  RSpec::Core::Version::STRING.split('.').first.to_i
+end
+
 Kernel.const_get(rspec_module)::Matchers.define :nilify_blanks_for do |column_name, options = {}|
   match do |model_instance|
     model_class = model_instance.class
@@ -10,11 +26,11 @@ Kernel.const_get(rspec_module)::Matchers.define :nilify_blanks_for do |column_na
     options.all? {|k, v| model_class.instance_variable_get(:@_nilify_blanks_options)[k] == v }
   end
 
-  failure_message_for_should do |ability|
+  send(failure_message_method) do |_|
     "expected to nilify blanks for #{column_name} #{options.inspect unless options.empty?}"
   end
 
-  failure_message_for_should_not do |ability|
+  send(negated_failure_message_method) do |_|
     "expected to not nilify blanks for #{column_name} #{options.inspect unless options.empty?}"
   end
 end
@@ -29,12 +45,11 @@ Kernel.const_get(rspec_module)::Matchers.define :nilify_blanks do |options = {}|
     options.all? {|k, v| model_class.instance_variable_get(:@_nilify_blanks_options)[k] == v }
   end
 
-  failure_message_for_should do |ability|
+  send(failure_message_method) do |_|
     "expected to nilify blanks #{options.inspect unless options.empty?}"
   end
 
-  failure_message_for_should_not do |ability|
+  send(negated_failure_message_method) do |_|
     "expected to not nilify blanks #{options.inspect unless options.empty?}"
   end
 end
-


### PR DESCRIPTION
Addresses #19 - RSpec 3 has deprecated the `failure_message_for_should` and `failure_message_for_should_not` methods. This PR adds support for the new `failure_message` and `failure_message_when_negated` methods for RSpec 3+ while retaining support for the legacy methods.