### PR TITLE
Use .columns instead of .content_columns

### DIFF
--- a/lib/nilify_blanks.rb
+++ b/lib/nilify_blanks.rb
@@ -65,7 +65,7 @@ module NilifyBlanks
         if options[:only]
           self.nilify_blanks_columns = options[:only].clone
         else
-          self.nilify_blanks_columns = self.content_columns.select(&:null).select {|c| options[:types].include?(c.type) }.map(&:name).map(&:to_s)
+          self.nilify_blanks_columns = self.columns.select(&:null).select {|c| options[:types].include?(c.type) }.map(&:name).map(&:to_s)
         end
 
         self.nilify_blanks_columns -= options[:except] if options[:except]

--- a/spec/db/schema.rb
+++ b/spec/db/schema.rb
@@ -1,5 +1,5 @@
 ActiveRecord::Schema.define(:version => 0) do
-  
+
   create_table :posts, :force => true do |t|
     t.string :first_name
     t.string :last_name, :null => false
@@ -7,6 +7,8 @@ ActiveRecord::Schema.define(:version => 0) do
     t.text :summary
     t.text :body
     t.integer :views
+    t.integer :category_id
+    t.string :blog_id
   end
-  
+
 end

--- a/spec/nilify_blanks_spec.rb
+++ b/spec/nilify_blanks_spec.rb
@@ -1,32 +1,33 @@
 require "spec_helper"
 
 describe NilifyBlanks do
-  
+
   context "Model with nilify_blanks" do
     before(:all) do
       class Post < ActiveRecord::Base
         nilify_blanks
       end
-      
-      @post = Post.new(:first_name => '', :last_name => '', :title => '', :summary => '', :body => '', :views => 0)
+
+      @post = Post.new(:first_name => '', :last_name => '', :title => '', :summary => '', :body => '', :views => 0, :blog_id => '')
       @post.save
     end
-    
+
     it "should recognize all non-null string, text columns" do
-      Post.nilify_blanks_columns.should == ['first_name', 'title', 'summary', 'body']
+      Post.nilify_blanks_columns.should == ['first_name', 'title', 'summary', 'body', 'blog_id']
     end
-    
+
     it "should convert all blanks to nils" do
       @post.first_name.should be_nil
       @post.title.should be_nil
       @post.summary.should be_nil
       @post.body.should be_nil
+      @post.blog_id.should be_nil
     end
-    
+
     it "should leave not-null last name field alone" do
       @post.last_name.should == ""
     end
-    
+
     it "should leave integer views field alone" do
       @post.views.should == 0
     end
@@ -38,79 +39,79 @@ describe NilifyBlanks do
         self.table_name = "posts"
         nilify_blanks :types => [:text]
       end
-      
+
       @post = PostOnlyText.new(:first_name => '', :last_name => '', :title => '', :summary => '', :body => '', :views => 0)
       @post.save
     end
-    
+
     it "should recognize all non-null text only columns" do
       PostOnlyText.nilify_blanks_columns.should == ['summary', 'body']
     end
-    
+
     it "should convert all blanks to nils" do
       @post.summary.should be_nil
       @post.body.should be_nil
     end
-    
+
     it "should leave not-null string fields alone" do
       @post.first_name.should == ""
       @post.last_name.should == ""
       @post.title.should == ""
     end
   end
-  
+
   context "Model with nilify_blanks :only => [:first_name, :title]" do
     before(:all) do
       class PostOnlyFirstNameAndTitle < ActiveRecord::Base
         self.table_name = "posts"
         nilify_blanks :only => [:first_name, :title]
       end
-      
+
       @post = PostOnlyFirstNameAndTitle.new(:first_name => '', :last_name => '', :title => '', :summary => '', :body => '', :views => 0)
       @post.save
     end
-    
+
     it "should recognize only first_name and title" do
       PostOnlyFirstNameAndTitle.nilify_blanks_columns.should == ['first_name', 'title']
     end
-    
+
     it "should convert first_name and title blanks to nils" do
       @post.first_name.should be_nil
       @post.title.should be_nil
     end
-    
+
     it "should leave other fields alone" do
       @post.summary.should == ""
       @post.body.should == ""
     end
   end
-  
+
   context "Model with nilify_blanks :except => [:first_name, :title]" do
     before(:all) do
       class PostExceptFirstNameAndTitle < ActiveRecord::Base
         self.table_name = "posts"
-        nilify_blanks :except => [:first_name, :title]
+        nilify_blanks :except => [:first_name, :title, :blog_id]
       end
-      
+
       @post = PostExceptFirstNameAndTitle.new(:first_name => '', :last_name => '', :title => '', :summary => '', :body => '', :views => 0)
       @post.save
     end
-    
+
     it "should recognize only summary, body, and views" do
       PostExceptFirstNameAndTitle.nilify_blanks_columns.should == ['summary', 'body']
     end
-    
+
     it "should convert summary and body blanks to nils" do
       @post.summary.should be_nil
       @post.body.should be_nil
     end
-    
+
     it "should leave other fields alone" do
       @post.first_name.should == ""
       @post.title.should == ""
     end
   end
-  
+
 
   context "Global Usage" do
     context "Namespaced Base Class with nilify_blanks inline" do


### PR DESCRIPTION
A couple reasons for this change:
  1) A column like `tax_id` of type `text` would be ignored by
     default, even though it would be a user inputted text field.
  2) Non integer foreign key columns should be nilified if blank.
     If I have a `blog_id` of type `text`, and the input supplies
     an empty string, it should be nilified.