### PR TITLE
Add citext to the list of default column types

### DIFF
--- a/lib/nilify_blanks.rb
+++ b/lib/nilify_blanks.rb
@@ -4,7 +4,7 @@ module NilifyBlanks
   end
 
   module ClassMethods
-    DEFAULT_TYPES = [:string, :text]
+    DEFAULT_TYPES = [:string, :text, :citext]
 
     @@define_nilify_blank_methods_lock = Mutex.new
 

--- a/spec/db/schema.rb
+++ b/spec/db/schema.rb
@@ -6,6 +6,7 @@ ActiveRecord::Schema.define(:version => 0) do
     t.string :title
     t.text :summary
     t.text :body
+    t.column :slug, :citext
     t.integer :views
   end
   


### PR DESCRIPTION
## Description
As part of Rails 4.2 (released a while ago), citext columns in PostgreSQL databases are recognized as a type distinct from `:text` and `:string` – `:citext` – when previously they were an unrecognized type and hence treated as `:string`s (see [relevant PR](https://github.com/rails/rails/pull/12523/files)). Citext columns are textual, so can evaluate `.blank? => true`, so the default column types should include it to check for blanks.

## Context
The upgrade to Rails 4.2 caused a uniqueness validation to fail on a project of mine. The Rails validation considered two blank `citext` strings not to clash (as `allow_blank` was set, assuming they would later be made nil), but they were no longer made into `nil` in the `before_save` callback added using this gem, as the columns were recognized as `:citext` instead of either of `:text` or `:string`. This caused the database uniqueness constraint to fail instead, as it compared the two blank strings and found them equal (whereas before it would be comparing two NULLs, finding them unequal as per SQL spec).

Accordingly, I think the default types constant should include `:citext`, so other users don't experience this problem, at least for Rails 4.2 plus. I can override it in my models by specifying types manually, and currently do, but think it would be good to include in the gem itself.

## Other Info
I had trouble figuring out how to test for this, because it looks like the RSpec tests are run using ActiveRecord 3.0, which doesn't have this change, so any citext columns will be treated as `string` columns by default. Further to that, the database used (at least by C Ruby) is SQLite, which doesn't to my knowledge support citext columns – they're PostgreSQL only. I hope my attempt isn't too botched?