### PR TITLE
Fix typo in Readme, should be ActiveRecord::Base not ActiveRecord::Before

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -68,7 +68,7 @@ Checking uses an ActiveRecord before_save filter by default, but you can specify
     nilify_blanks :before => :create
   end
   
-  class Post < ActiveRecord::Before
+  class Post < ActiveRecord::Base
     nilify_blanks :before => :validation_on_update
   end
 


### PR DESCRIPTION
Fixing typo in documentation.