### PR TITLE
BUG: nilify_blanks not matching when column name ends with _id or _count

### DIFF
--- a/lib/nilify_blanks/matchers.rb
+++ b/lib/nilify_blanks/matchers.rb
@@ -43,7 +43,7 @@ Kernel.const_get(rspec_module)::Matchers.define :nilify_blanks do |options = {}|
     model_class.define_attribute_methods
     model_class.included_modules.include?(NilifyBlanks::InstanceMethods) &&
     model_class.respond_to?(:nilify_blanks_columns) &&
-    model_class.nilify_blanks_columns == model_class.content_columns.select(&:null).select {|c| options[:types].include?(c.type) }.map(&:name).map(&:to_s) &&
+    model_class.nilify_blanks_columns == model_class.columns.select(&:null).select {|c| options[:types].include?(c.type) }.map(&:name).map(&:to_s) &&
     options.all? {|k, v| model_class.instance_variable_get(:@_nilify_blanks_options)[k] == v }
   end
 

--- a/spec/nilify_blanks_spec.rb
+++ b/spec/nilify_blanks_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require "nilify_blanks/matchers"
 
 RSpec.describe NilifyBlanks do
   context "Model with nilify_blanks" do
@@ -30,6 +30,10 @@ RSpec.describe NilifyBlanks do
 
     it "should leave integer views field alone" do
       expect(@post.views).to eq(0)
+    end
+
+    it "should not nilify non-null column" do
+      expect(@post.class.nilify_blanks_columns).to_not include('last_name')
     end
   end
 
@@ -201,5 +205,41 @@ RSpec.describe NilifyBlanks do
       end
     end
 
+  end
+
+  describe "matchers" do
+    describe "nilify_blanks_for" do
+      subject { Post.new }
+
+      before(:all) do
+        class Post < ActiveRecord::Base
+          nilify_blanks
+        end
+      end
+
+      it { is_expected.to nilify_blanks_for(:first_name) }
+      it { is_expected.to nilify_blanks_for(:title) }
+      it { is_expected.to nilify_blanks_for(:summary) }
+      it { is_expected.to nilify_blanks_for(:body) }
+      it { is_expected.to nilify_blanks_for(:slug) }
+      it { is_expected.to nilify_blanks_for(:blog_id) }
+
+      it { is_expected.to_not nilify_blanks_for(:id) }
+      it { is_expected.to_not nilify_blanks_for(:last_name) }
+    end
+
+    describe "nilify_blanks" do
+      subject { Post.new }
+
+      before(:all) do
+        class Post < ActiveRecord::Base
+          nilify_blanks
+        end
+      end
+
+      context "foreign key column is nilified" do
+        it { is_expected.to nilify_blanks }
+      end
+    end
   end
 end


### PR DESCRIPTION
In `nilify_blanks` matcher there is check for equality between nilified columns and model columns to ensure that all nullable columns are being used. This would fail in case when nilified column ends with `_id` or `_count` due to used `Model.content_columns` function:
https://github.com/rails/rails/blame/master/activerecord/lib/active_record/model_schema.rb#L414
To avoid this use plain `columns` without pk included.