### PR TITLE
gemspec: Drop unused rubyforge_project directive

### DIFF
--- a/nilify_blanks.gemspec
+++ b/nilify_blanks.gemspec
@@ -8,14 +8,13 @@ Gem::Specification.new do |s|
   s.license     = 'MIT'
   s.author      = "Ben Hughes"
   s.email       = "ben@railsgarden.com"
-  s.homepage    = "http://github.com/rubiety/nilify_blanks"
+  s.homepage    = "https://github.com/rubiety/nilify_blanks"
   s.summary     = "Auto-convert blank fields to nil."
   s.description = "Often times you'll end up with empty strings where you really want nil at the database level.  This plugin automatically converts blanks to nil and is configurable."
 
   s.files        = Dir["{lib,spec}/**/*", "[A-Z]*", "init.rb"]
   s.require_path = "lib"
 
-  s.rubyforge_project = s.name
   s.required_rubygems_version = ">= 1.3.4"
 
   s.add_dependency("activesupport", [">= 4.0.0"])


### PR DESCRIPTION
The RubyGems gemspec property `rubyforge_project` has been removed without a replacement. This PR removes that property.

## Background

* [RubyForge was closed down in 2013][1].
* rubygems/rubygems#2436 deprecated the `rubyforge_project` property

[1]: https://twitter.com/evanphx/status/399552820380053505