### PR TITLE
Fix Bundler Mismatch in CI Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,10 @@ matrix:
       rvm: 2.4.5
 
 before_install:
-  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
   - gem install bundler -v '< 2'
   - "rm gemfiles/*.lock"
 
-before_script:
-  - "bundle install"
+install:
+  - bundle _1.17.3_ install --retry=3 --jobs=3
 
 script: "bundle exec rake clean test"


### PR DESCRIPTION
# Problem

I noticed that the CI build was failing on Travis and it looked like Travis was running its own `bundle install` step with some global version of `bundler` that wasn't uninstalled by the `before_install` `gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true`.  At least that appeared to be the case for Ruby 2.5.3 builds against Rails 4.  I figure nobody loves a broken CI build, so I made an attempt at patching it up.

# Solution

Override Travis CI's install step and ensure that bundler v1.17.3 is used to install gems in all builds.

# Concerns

If you would like to use a more recent version of `bundler` in Rails 5+ builds, I would need to investigate how to make that happen 😀 .  For now, though, this seems to fix the build, so I am wondering if it is worth merging in.